### PR TITLE
Update 0.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,13 +26,14 @@ requirements:
     - convertdate >=2.3.0
     - korean_lunar_calendar
     - hijri-converter
+    - pymeeus
 
 test:
   imports:
     - holidays
   requires:
     # due to conda build bug which causes python 3.10 to be used
-    - python <3.10
+    # - python <3.10
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e94d9d3536ff1a2a70d6d2f56cb055eb9a95d0b9a3a5fb81b9e8f9d36e333789
 
 build:
-  skip: True     # [py<36]
+  skip: True     # [py<37]
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "holidays" %}
-{% set version = "0.11.3.1" %}
+{% set version = "0.18" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4855afe0ebf428efbcf848477828b889f8515be7f4f15ae26682919369d92774
+  sha256: e94d9d3536ff1a2a70d6d2f56cb055eb9a95d0b9a3a5fb81b9e8f9d36e333789
 
 build:
   skip: True     # [py<36]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   skip: True     # [py<37]
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,6 @@ test:
   imports:
     - holidays
   requires:
-    # due to conda build bug which causes python 3.10 to be used
-    # - python <3.10
     - pip
   commands:
     - pip check


### PR DESCRIPTION
Jira ticket: https://anaconda.atlassian.net/browse/PKG-992
Upsream repo: https://github.com/dr-prodigy/python-holidays
Changelog: https://github.com/dr-prodigy/python-holidays/blob/master/CHANGES

### Steps Taken

1. Update version # and sha256
2. Update python version skip to [py<37 ](https://github.com/dr-prodigy/python-holidays/blob/39f3538764e7413c3b7a15426e065294238ce493/setup.cfg#L38)
3. Remove noarch build
4. added [pymeeus](https://github.com/dr-prodigy/python-holidays/blob/39f3538764e7413c3b7a15426e065294238ce493/setup.cfg#L33) as a dependency
5. Conda build no longer has a bug, so this [test parameter](https://github.com/AnacondaRecipes/holidays-feedstock/pull/2/commits/1d36756f9c008defea518c44369c01347110af73) was removed