### PR TITLE
bump up version to 0.48

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "holidays" %}
-{% set version = "0.29" %}
+{% set version = "0.48" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e8219df1570dd92f17244ff7da93f57630b0dd2fedf86e86b4110f07825b0a67
+  sha256: 8801d45e15600990494988b193cd83ef470f59138bd964bbdf5f023f17cc7966
 
 build:
   number: 0
@@ -49,3 +49,4 @@ extra:
     - bletham
     - rpanai
     - synapticarbors
+    


### PR DESCRIPTION
Holidays 0.48 

**Destination channel:** defaults

### Links

- [{PKG-4660}](https://anaconda.atlassian.net/browse/PKG-4660) 
- [Upstream](https://github.com/vacanza/python-holidays/tree/v0.48/holidays)

  