### PR TITLE
holidays v0.83

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "holidays" %}
-{% set version = "0.48" %}
+{% set version = "0.83" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8801d45e15600990494988b193cd83ef470f59138bd964bbdf5f023f17cc7966
+  sha256: 99b97b002079ab57dac93295933907d2aae2742ad9a4d64fe33864dfae6805fa
 
 build:
   number: 0
@@ -32,7 +32,7 @@ test:
     - pip check
 
 about:
-  home: https://github.com/dr-prodigy/python-holidays
+  home: https://github.com/vacanza/holidays
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -41,7 +41,7 @@ about:
     A fast, efficient Python library for generating country, province and state
     specific sets of holidays on the fly. It aims to make determining whether a
     specific date is a holiday as fast and flexible as possible.
-  dev_url: https://github.com/dr-prodigy/python-holidays
+  dev_url: https://github.com/vacanza/holidays
   doc_url: https://pypi.org/project/holidays/
 
 extra:


### PR DESCRIPTION
holidays 0.83

**Destination channel:** defaults

### Links

- [PKG-10359](https://anaconda.atlassian.net/browse/PKG-10359) 
- Upstream: [https://github.com/vacanza/holidays/tree/dev/tests](https://github.com/vacanza/holidays/tree/dev/tests)
- Upstream changelog: [https://github.com/vacanza/holidays/blob/dev/CHANGES.md#version-083](https://github.com/vacanza/holidays/blob/dev/CHANGES.md#version-083)

### Explanation of changes:

- Updating to 0.83
- Fix dev_url to point to correct up-to-date repo. Old dev_url referenced a repo that had been branched by a developer and not maintained.


[PKG-10359]: https://anaconda.atlassian.net/browse/PKG-10359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ